### PR TITLE
Mhs/das 2292/regression tests for smap l2 gridder (#1)

### DIFF
--- a/.github/workflows/notebook-test-suite.yml
+++ b/.github/workflows/notebook-test-suite.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      - name: who owns this?
+        run: echo ${{ github.repository_owner }}
+
       - name: Pull Docker image
         run: docker pull ghcr.io/${{github.repository_owner}}/regression-tests-${{ matrix.service }}:${{ github.event.client_payload.docker-image-tag || inputs.docker-image-tag || 'latest' }}
 


### PR DESCRIPTION
* DAS-2292: Stub for regression tests.

* DAS-2292: Adds tests for SPL2SMP_E and SPL2SMAP

* DAS-2292: Bumps Xarray version

Also pass in keyword arg decode_timedelta=False.
This was raising a deprecation error and used to default to None.

* DAS-2292: Adds regression data for SPL2SMP_E AND SPL2SMAP

* DAS-2292: Update Changelog

* DAS-2292: add files to lfs at root level## Description

A short description of the changes in this PR...

## Jira Issue ID


## Local Test Steps


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] CHANGELOG updated with the changes for this PR
